### PR TITLE
Wrap checks on document.body

### DIFF
--- a/source/views/layouts/govuk_template.html.erb
+++ b/source/views/layouts/govuk_template.html.erb
@@ -37,7 +37,11 @@
   </head>
 
   <body<%= content_for?(:body_classes) ? raw(" class=\"#{yield(:body_classes)}\"") : '' %>>
-    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+      });
+    </script>
 
     <%= yield :body_start %>
 


### PR DESCRIPTION
On IE11 we often fail to run JS code because when this line of code gets executed the `document.body` is not loaded yet.